### PR TITLE
Remove unnecessary import

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,6 @@ This example is a part of [`demo/`](https://github.com/zeronnia/vue3-notion/demo
 
 ```vue
 <script setup lang="ts">
-import { useNuxtApp } from "#app"
-
 const { $notion } = useNuxtApp()
 const { data } = await useAsyncData("notion", () => $notion.getPageBlocks("2e22de6b770e4166be301490f6ffd420"))
 </script>


### PR DESCRIPTION
This PR removes an unnecessary import in the Nuxt v3 example.

This is not necessary since Nuxt already auto-imports `useNuxtApp`. From what I understand, if this line was to be kept, it should be changed to import it from `#imports` instead, since that's were Nuxt exposes everything in `#app` as well as other stuff.

More details about this in the docs: https://v3.nuxtjs.org/guide/concepts/auto-imports#explicit-imports